### PR TITLE
Consume master branches of the C++ components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,10 @@ RUN pip install Genshi
 RUN pip install Sphinx
 
 WORKDIR /git
-RUN git clone --branch='v5.4.2' https://github.com/ome/ome-common-cpp.git
-RUN git clone --branch='v5.5.6' https://github.com/ome/ome-model.git
-RUN git clone --branch='v0.4.0' https://github.com/ome/ome-files-cpp.git
-RUN git clone --branch='v5.4.2' https://github.com/ome/ome-qtwidgets.git
-RUN git clone --branch='v0.4.0' https://github.com/ome/ome-cmake-superbuild.git
+RUN git clone --branch='master' https://github.com/ome/ome-common-cpp
+RUN git clone --branch='master' https://github.com/ome/ome-model
+RUN git clone --branch='master' https://github.com/ome/ome-files-cpp
+RUN git clone --branch='master' https://github.com/ome/ome-cmake-superbuild
 
 WORKDIR /build
 RUN cmake3 \


### PR DESCRIPTION
See https://trello.com/c/YJBB1cOA/11-centos-7-platform-support

Following the review of the minimal Boost requirements (see https://github.com/ome/ome-common-cpp/pull/49, https://github.com/ome/ome-model/pull/51, https://github.com/ome/ome-files-cpp/pull/83 and  https://github.com/ome/ome-qtwidgets/pull/29), this PR consumes the `master` branches of the various C++ components.

To test this PR:
- check that the [Hub Docker image](https://hub.docker.com/r/snoopycrimecop/ome-files-cpp-c7/) builds as expected
- and/or build the image locally `docker built -t ome-files-cpp-c7 .`
- check the image is functional by running `ome-files info` against a sample OME-TIFF file