### PR TITLE
Include /usr/local/lib in ldconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,5 @@ RUN cmake3 \
     /git/ome-cmake-superbuild
 RUN make
 RUN make install
+RUN cat "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf
 RUN ldconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ RUN cmake3 \
     /git/ome-cmake-superbuild
 RUN make
 RUN make install
-RUN cat "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf
 RUN ldconfig


### PR DESCRIPTION
Noticed while consuming the ome-files-cpp-c7 base image from ome-files-py, the default ldconfig configuration files on CentOS7 do not include /usr/local/lib.

To reproduce, check the latest image does not report any OME library:

```
$ docker pull openmicroscopy/ome-files-cpp-c7
$ docker run --rm -it openmicroscopy/ome-files-cpp-c7 ldconfig -v | grep libome
```

To test this PR, build the image locally

```
$ docker build -t ome-files-cpp-c7 .
$ docker run --rm -it ome-files-cpp-c7 ldconfig -v | grep libome
```

or pull the daily merge image pushed to Docker Hub

```
$ docker pull snoopycrimecop/ome-files-cpp-c7:master_merge_daily
$ docker run --rm -it snoopycrimecop/ome-files-cpp-c7:master_merge_daily ldconfig -v | grep libome
```

In either case, the `ldconfig -v` output should return the various OME Files libraries (common, model, files)