### PR TITLE
Build with devtoolset-4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN yum install -y \
   locales \
   python-pip
 
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-4-toolchain
+
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
@@ -31,14 +34,14 @@ RUN git clone --branch='master' https://github.com/ome/ome-files-cpp
 RUN git clone --branch='master' https://github.com/ome/ome-cmake-superbuild
 
 WORKDIR /build
-RUN cmake3 \
+RUN scl enable devtoolset-4 -- cmake3 \
     -Dgit-dir=/git \
     -Dbuild-prerequisites=OFF \
     -Dome-superbuild_BUILD_gtest=ON \
     -Dbuild-packages=ome-files \
     -DCMAKE_BUILD_TYPE=Release \
     /git/ome-cmake-superbuild
-RUN make
-RUN make install
+RUN scl enable devtoolset-4 -- make
+RUN scl enable devtoolset-4 -- make install
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf
 RUN ldconfig


### PR DESCRIPTION
Required to build ome-files-py with pybind11 and https://github.com/ome/ome-files-py/pull/25.

Build with devtoolset-4.  Requirement for pybind11 noted during investigation here: https://trello.com/c/5UxvgXm1/6-ome-files-python-pybind11#comment-599415a427b8e5bc77cdc4b2

Testing:

- run docker build; note the latest hash
- check out https://github.com/ome/ome-files-py/pull/25 and alter `Dockerfile.c7` to use the hash noted above in the FROM line.  Run docker build, which should now pass.